### PR TITLE
Add support for organization-owned repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 <p align="center">A GitHub Action that labels issues/PRs if the creator is a sponsor of the owner</p>
 <p align="center"><a href="https://github.com/JasonEtco/is-sponsor-label-action"><img alt="GitHub Actions status" src="https://github.com/JasonEtco/is-sponsor-label-action/workflows/Node%20CI/badge.svg"></a> <a href="https://codecov.io/gh/JasonEtco/is-sponsor-label-action/"><img src="https://badgen.now.sh/codecov/c/github/JasonEtco/is-sponsor-label-action" alt="Codecov"></a></p>
 
-**Note**: currently only works for user-owned repositories. This is due to a limitation of the GraphQL API, since we can't query for a "user or organization" in one request.
-
 ## Examples
 
 Imagine Alice sponsors Bob through GitHub Sponsors, and Bob owns a public repo, which includes this `sponsor-label` action. Then, when Alice opens an issue or PR on that repo, a bot will automatically add a `sponsor 💖` label.

--- a/lib/user-is-sponsor.js
+++ b/lib/user-is-sponsor.js
@@ -39,7 +39,7 @@ module.exports = async function userIsSponsor (tools, nodeId) {
       after
     })
 
-    const { nodes, pageInfo } = result.user.sponsorshipsAsMaintainer
+    const { nodes, pageInfo } = result[ownerType].sponsorshipsAsMaintainer
 
     // Check if the issue/PR creator is a sponsor
     if (nodes.find(node => node.sponsor.id === nodeId)) {

--- a/lib/user-is-sponsor.js
+++ b/lib/user-is-sponsor.js
@@ -6,8 +6,14 @@
  * @returns {boolean}
  */
 module.exports = async function userIsSponsor (tools, nodeId) {
+  // This will be either Organization or User
+  const ownerType = tools.context.payload.repository.owner.type.toLowerCase()
+  if (!['user', 'organization'].includes(ownerType)) {
+    throw new Error(`Repository owner type ${ownerType} is not supported.`)
+  }
+
   const query = `query ($owner: String!, $after: String) { 
-    user (login: $owner) {
+    ${ownerType} (login: $owner) {
       sponsorshipsAsMaintainer (first: 100, after: $after) {
         pageInfo {
           hasNextPage

--- a/tests/fixtures/not-sponsor.json
+++ b/tests/fixtures/not-sponsor.json
@@ -11,6 +11,7 @@
     "id": 110556535,
     "name": "testing",
     "owner": {
+      "type": "User",
       "login": "JasonEtco"
     }
   }

--- a/tests/fixtures/sponsor.json
+++ b/tests/fixtures/sponsor.json
@@ -11,6 +11,7 @@
     "id": 29001594,
     "name": "awesome-gametalks",
     "owner": {
+      "type": "User",
       "login": "hzoo"
     }
   }

--- a/tests/user-is-sponsor.test.js
+++ b/tests/user-is-sponsor.test.js
@@ -108,4 +108,35 @@ describe('userIsSponsor', () => {
     const result = await userIsSponsor(tools, nodeId)
     expect(result).toBe(false)
   })
+
+  it('returns true if the user is a sponsor for an organization-owned repo', async () => {
+    const nodeId = 'hi'
+    tools.context.payload.repository.owner.type = 'Organization'
+
+    nocked.reply(200, {
+      data: {
+        organization: {
+          sponsorshipsAsMaintainer: {
+            pageInfo: {
+              hasNextPage: false
+            },
+            nodes: [{
+              sponsor: {
+                id: nodeId
+              }
+            }]
+          }
+        }
+      }
+    })
+
+    const result = await userIsSponsor(tools, nodeId)
+    expect(result).toBe(true)
+  })
+
+  it('throws if the repository owner type is invalid', async () => {
+    const nodeId = 'hi'
+    tools.context.payload.repository.owner.type = 'Pizza'
+    await expect(userIsSponsor(tools, nodeId)).rejects.toThrow()
+  })
 })


### PR DESCRIPTION
This PR adds support for organization-owned repositories. Thankfully, the GraphQL query is exactly the same, aside from the name of the top-level object (`user/organization`) - so we can inspect the payload to see the owner's `type` and modify the query a little.