### PR TITLE
Don't fail if the label already exists

### DIFF
--- a/lib/create-label.js
+++ b/lib/create-label.js
@@ -11,7 +11,8 @@ module.exports = async function createLabel (tools) {
     await tools.github.issues.createLabel({
       ...tools.context.repo,
       name: label,
-      color: 'fedbf0'
+      color: 'fedbf0',
+      request: { retries: 0 }
     })
   } catch {}
 }

--- a/lib/create-label.js
+++ b/lib/create-label.js
@@ -8,7 +8,7 @@ module.exports = async function createLabel (tools) {
   const label = tools.inputs.label
   tools.log.debug(`Making label [${label}]`)
   try {
-    return tools.github.issues.createLabel({
+    await tools.github.issues.createLabel({
       ...tools.context.repo,
       name: label,
       color: 'fedbf0'

--- a/tests/add-label.test.js
+++ b/tests/add-label.test.js
@@ -34,15 +34,4 @@ describe('addLabel', () => {
       labels: ['sponsor 💖']
     })
   })
-
-  it('does not bork if the label already exists', async () => {
-    nocked = nocked.replyWithError(400, (_, body) => { params = body })
-
-    await addLabel(tools)
-
-    expect(nocked.isDone()).toBe(true)
-    expect(params).toMatchObject({
-      labels: ['sponsor 💖']
-    })
-  })
 })

--- a/tests/add-label.test.js
+++ b/tests/add-label.test.js
@@ -36,7 +36,7 @@ describe('addLabel', () => {
   })
 
   it('does not bork if the label already exists', async () => {
-    nocked = nocked.replyWithError(500, (_, body) => { params = body })
+    nocked = nocked.replyWithError(400, (_, body) => { params = body })
 
     await addLabel(tools)
 

--- a/tests/add-label.test.js
+++ b/tests/add-label.test.js
@@ -34,4 +34,15 @@ describe('addLabel', () => {
       labels: ['sponsor 💖']
     })
   })
+
+  it('does not bork if the label already exists', async () => {
+    nocked = nocked.replyWithError(500, (_, body) => { params = body })
+
+    await addLabel(tools)
+
+    expect(nocked.isDone()).toBe(true)
+    expect(params).toMatchObject({
+      labels: ['sponsor 💖']
+    })
+  })
 })

--- a/tests/create-label.test.js
+++ b/tests/create-label.test.js
@@ -36,7 +36,7 @@ describe('createLabel', () => {
 
     expect(nocked.isDone()).toBe(true)
     expect(params).toMatchObject({
-      labels: ['sponsor 💖']
+      name: 'sponsor 💖'
     })
   })
 })

--- a/tests/create-label.test.js
+++ b/tests/create-label.test.js
@@ -28,4 +28,15 @@ describe('createLabel', () => {
       name: 'sponsor 💖'
     })
   })
+
+  it('does not bork if the label already exists', async () => {
+    nocked = nocked.replyWithError(400, (_, body) => { params = body })
+
+    await createLabel(tools)
+
+    expect(nocked.isDone()).toBe(true)
+    expect(params).toMatchObject({
+      labels: ['sponsor 💖']
+    })
+  })
 })


### PR DESCRIPTION
The action tries to create the label, and should work even if the label already exists. Unfortunately that doesn't seem to be happening. So far I just added a failing test and will try out some ways to fix it!

Closes #6 