### PR TITLE
fix: node.sponsor can be null

### DIFF
--- a/lib/user-is-sponsor.js
+++ b/lib/user-is-sponsor.js
@@ -42,7 +42,7 @@ module.exports = async function userIsSponsor (tools, nodeId) {
     const { nodes, pageInfo } = result[ownerType].sponsorshipsAsMaintainer
 
     // Check if the issue/PR creator is a sponsor
-    if (nodes.find(node => node.sponsor.id === nodeId)) {
+    if (nodes.find(node => node.sponsor && node.sponsor.id === nodeId)) {
       return true
     }
 


### PR DESCRIPTION
fixes #16


Below is the `nodes` variable debugged for my flow.
```
[
  { sponsor: { id: 'MDQ6VXNlcjE5NjI5ODI=' } },
  { sponsor: { id: 'MDQ6VXNlcjQ5NzE3MTU=' } },
  { sponsor: { id: 'MDQ6VXNlcjc1NDkyOTU=' } },
  { sponsor: { id: 'MDQ6VXNlcjEwNzc4NjYx' } },
  { sponsor: { id: 'MDQ6VXNlcjExNzUzODY3' } },
  { sponsor: null },
  { sponsor: { id: 'MDQ6VXNlcjM1MDk4Mjg3' } },
  { sponsor: { id: 'MDQ6VXNlcjU5ODc2NTY1' } }
]
```