### PR TITLE
Use sponsorEntity field instead of deprecated sponsor field

### DIFF
--- a/lib/user-is-sponsor.js
+++ b/lib/user-is-sponsor.js
@@ -12,7 +12,7 @@ module.exports = async function userIsSponsor (tools, nodeId) {
     throw new Error(`Repository owner type ${ownerType} is not supported.`)
   }
 
-  const query = `query ($owner: String!, $after: String) { 
+  const query = `query ($owner: String!, $after: String) {
     ${ownerType} (login: $owner) {
       sponsorshipsAsMaintainer (first: 100, after: $after) {
         pageInfo {
@@ -20,8 +20,8 @@ module.exports = async function userIsSponsor (tools, nodeId) {
           endCursor
         }
         nodes {
-          sponsor {
-            id
+          sponsorEntity {
+            ... on User { id }
           }
         }
       }

--- a/lib/user-is-sponsor.js
+++ b/lib/user-is-sponsor.js
@@ -42,7 +42,7 @@ module.exports = async function userIsSponsor (tools, nodeId) {
     const { nodes, pageInfo } = result[ownerType].sponsorshipsAsMaintainer
 
     // Check if the issue/PR creator is a sponsor
-    if (nodes.find(node => node.sponsor && node.sponsor.id === nodeId)) {
+    if (nodes.find(node => node.sponsorEntity && node.sponsorEntity.id === nodeId)) {
       return true
     }
 

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -27,7 +27,7 @@ describe('is-sponsor-label', () => {
           user: {
             sponsorshipsAsMaintainer: {
               nodes: [{
-                sponsor: {
+                sponsorEntity: {
                   id: tools.context.payload.issue.user.node_id
                 }
               }]

--- a/tests/user-is-sponsor.test.js
+++ b/tests/user-is-sponsor.test.js
@@ -31,7 +31,7 @@ describe('userIsSponsor', () => {
         user: {
           sponsorshipsAsMaintainer: {
             nodes: [{
-              sponsor: {
+              sponsorEntity: {
                 id: nodeId
               }
             }]
@@ -70,7 +70,7 @@ describe('userIsSponsor', () => {
               endCursor: 'endCursor'
             },
             nodes: [{
-              sponsor: {
+              sponsorEntity: {
                 id: nodeId
               }
             }]
@@ -96,7 +96,7 @@ describe('userIsSponsor', () => {
               hasNextPage: false
             },
             nodes: [{
-              sponsor: {
+              sponsorEntity: {
                 id: 'nope'
               }
             }]
@@ -121,7 +121,7 @@ describe('userIsSponsor', () => {
               hasNextPage: false
             },
             nodes: [{
-              sponsor: {
+              sponsorEntity: {
                 id: nodeId
               }
             }]


### PR DESCRIPTION
The `Sponsorship.sponsor` field is deprecated, according to https://docs.github.com/en/graphql/reference/objects#sponsorship. This updates the GraphQL query to use the preferred `sponsorEntity` field. I kept it grabbing just the ID for a user sponsor, given that I think you're only looking up user sponsors since it's the author of a pull request or issue.